### PR TITLE
[tl] Fix pipeline bugs. Fix thread binding bugs on sm_90 arch.

### DIFF
--- a/python/tvm/tl/engine.py
+++ b/python/tvm/tl/engine.py
@@ -64,7 +64,7 @@ def tvm_callback_cuda_compile(code, target):
             "-I" + tl_template_path,
             "-I" + cutlass_path,
         ],
-        get_output=True,
+        get_output=False,
     )
     # with open("save.ptx", "wb") as f:
     #     f.write(ptx)

--- a/python/tvm/tl/utils.py
+++ b/python/tvm/tl/utils.py
@@ -171,6 +171,7 @@ class Profiler(ConvertTorch):
         ins = self._get_inputs()
         if not func:
             func = self.__call__
+        return func(*ins)
 
     def do_bench(
         self,

--- a/src/tl/ir.cc
+++ b/src/tl/ir.cc
@@ -74,10 +74,10 @@ ForFrame PipelinedFor(
     ICHECK(n == 1);
     Map<String, ObjectRef> anno;
     if (num_stages > 0) anno.Set("num_stages", PrimExpr(num_stages));
-    anno.Set("software_pipeline_order", order);
-    anno.Set("software_pipeline_stage", stages);
-    anno.Set("software_pipeline_sync", sync);
-    anno.Set("software_pipeline_group", groups);
+    anno.Set("tl_pipeline_order", order);
+    anno.Set("tl_pipeline_stage", stages);
+    anno.Set("tl_pipeline_sync", sync);
+    anno.Set("tl_pipeline_group", groups);
     body = For(vars[0], doms[0]->min, doms[0]->extent, ForKind::kSerial, std::move(body),
                /*thread_binding=*/NullOpt, /*annotations=*/anno);
     return body;

--- a/src/tl/transform/lower_hopper_intrin.cc
+++ b/src/tl/transform/lower_hopper_intrin.cc
@@ -80,7 +80,7 @@ class LowerHopperIntrin : public StmtExprMutator {
 
           auto stmts = prefetch_calls_;
           stmts.insert(stmts.end(), init_mbarrier_calls_.begin(), init_mbarrier_calls_.end());
-          auto init_stmt = IfThenElse(EQ(iv->var, 0), SeqStmt(stmts));
+          auto init_stmt = IfThenElse(EQ(iv->var, 0), stmts.size() > 1 ? SeqStmt(stmts) : stmts[0]);
           stmt_seq.push_back(init_stmt);
           if (!init_mbarrier_calls_.empty()) {
             Stmt mem_sync = Evaluate(


### PR DESCRIPTION
1. Fix bug on T.Pipelined().
2. Fix bug in thread binding for the sm_90 architecture. Previously, the warp_specialize pass failed to correctly analyze the thread binding when used.